### PR TITLE
fixed membership on the angle portions of the left and right shoulders

### DIFF
--- a/src/fl/mamdani.py
+++ b/src/fl/mamdani.py
@@ -83,8 +83,10 @@ class MamdaniAntecedent(FuzzyAntecedent):
             if not (node.left or node.right):
                 raise ValueError('left and right operands must exist')
             if node.operator == Rule.FR_AND:
-                return tnorm(self.firing_strength(tnorm, snorm, node=self.left),
-                             self.firing_strength(tnorm, snorm, node=self.right))
+                return tnorm(self.firing_strength(tnorm, snorm, node=node.left),
+                             self.firing_strength(tnorm, snorm, node=node.right))
+                #return tnorm(self.firing_strength(tnorm, snorm, node=self.left),  # TODO:  Is the previous change right????
+                #            self.firing_strength(tnorm, snorm, node=self.right))
             elif node.operator == Rule.FR_OR:
                 return snorm(self.firing_strength(tnorm, snorm, node=self.left),
                              self.firing_strength(tnorm, snorm, node=self.right))

--- a/src/fl/term.py
+++ b/src/fl/term.py
@@ -168,7 +168,7 @@ class LeftShoulder(Term):
     def membership(self, x):
         if x <= self.minimum: return 1.0
         if x >= self.maximum: return 0.0
-        return (x - self.minimum) / (self.maximum - self.minimum)
+        return 1.0 - ((x - self.minimum) / (self.maximum - self.minimum))
         
 
 class RightShoulder(Term):
@@ -185,7 +185,7 @@ class RightShoulder(Term):
     def membership(self, x):
         if x <= self.minimum: return 0.0
         if x >= self.maximum: return 1.0
-        return (self.maximum - x) / (self.maximum - self.minimum)
+        return 1.0 - ((self.maximum - x) / (self.maximum - self.minimum))
 
 
 class Lambda(Term):


### PR DESCRIPTION
1. Fixes problem when referencing left/right nodes in the AND operator.

2. Fixes membership in the angle portion of the left and right shoulders:
```
 ------------\
             1 \
                 \
                  \
                   \
                     \2
```
Membership at point 1 is now '1' and decreases to 0 at point 2.   Before the fix, membership at point 1 was 0 and would increase to 1 at point 2.    The same for the right shoulder.

 