### PR TITLE
Fix: engine [input|output]_values

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# Version 8.0.2
+
+### Bug fixes
+
+- Fix `engine.[input|output]_values`, which was not working correctly when manually setting variable values (issue #75).
+
 # Version 8.0.1
 
 ### Bug fixes
@@ -24,10 +30,10 @@
 - function `fl.to_float` converts any argument to a `float`, which was the behaviour of `fl.Op.scalar`.
 - linguistic terms `Arc` and `SemiEllipse`
 - indexable components:
-    - `Engine`: get variables or rule blocks by name using square brackets, eg, `engine["light"].value`
-    - `Variable`: get terms by name using square brackets, eg, `variable["low"].membership(value)`
-    - `Factory`: get constructors and objects by name using square brackets,
-      eg, `factory["Triangle"]()`, `factory["sin"](3.14)`
+  - `Engine`: get variables or rule blocks by name using square brackets, eg, `engine["light"].value`
+  - `Variable`: get terms by name using square brackets, eg, `variable["low"].membership(value)`
+  - `Factory`: get constructors and objects by name using square brackets,
+    eg, `factory["Triangle"]()`, `factory["sin"](3.14)`
 - class `Benchmark` to benchmark engines
 - `from __future__ import annotations` in every file to use better type annotations
 - class `library.Settings` to configure general settings in singleton `library.settings`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pyfuzzylite 8.0.1
+# pyfuzzylite 8.0.2
 
 <img src="https://fuzzylite.github.io/pyfuzzylite/image/fuzzylite.svg" align="left" alt="fuzzylite">
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# pyfuzzylite 8.0.1
+# pyfuzzylite 8.0.2
 
 ***
 

--- a/fuzzylite/engine.py
+++ b/fuzzylite/engine.py
@@ -323,9 +323,9 @@ class Engine:
             ValueError: when the dimensionality of values is greater than 2
             ValueError: when the number of columns in the values is different from the number of input variables
         """
-        return np.atleast_2d(  # type:ignore
-            np.array([v.value for v in self.input_variables])
-        ).T
+        values = tuple(input_variable.value for input_variable in self.input_variables)
+        result = np.column_stack(values) if values else np.array(values)
+        return result
 
     @input_values.setter
     def input_values(self, values: ScalarArray) -> None:
@@ -379,9 +379,9 @@ class Engine:
             2D array of output values (rows) for each output variable (columns).
         """
         # TODO: Maybe a property setter like input_values.
-        return np.atleast_2d(  # type:ignore
-            np.array([v.value for v in self.output_variables])
-        ).T
+        values = tuple(output_variable.value for output_variable in self.output_variables)
+        result = np.column_stack(values) if values else np.array(values)
+        return result
 
     @property
     def values(self) -> ScalarArray:

--- a/fuzzylite/library.py
+++ b/fuzzylite/library.py
@@ -272,7 +272,7 @@ class Information:
         Returns:
             version of the library
         """
-        __version__ = "8.0.1"
+        __version__ = "8.0.2"
         return __version__
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyfuzzylite"
-version = "8.0.1"
+version = "8.0.2"
 description = "a fuzzy logic control library in Python"
 license = "Proprietary"
 readme = "README.md"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -76,7 +76,7 @@ variable InputVariable OutputVariable Variable
 
     def test_library_vars(self) -> None:
         """Test the library variables."""
-        __version__ = "8.0.1"
+        __version__ = "8.0.2"
         self.assertEqual(fl.__name__, "fuzzylite")
         self.assertEqual(fl.__version__, __version__)
         self.assertEqual(fl.__doc__, fl.information.description)


### PR DESCRIPTION
Fixes issue found #75, where `engine.input_values` was transposing an array it shouldn't, causing `Linear` to output multiple values instead of one.