### PR TITLE
chore(bench): update CodSpeed/action to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: coverallsapp/github-action@v2
 
       - name: Benchmark
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: nox -e benchmark -- codspeed


### PR DESCRIPTION
Upgrading to the v2 of https://github.com/CodSpeedHQ/action will bring a better base run selection algorithm, better logging, and continued support.