### PR TITLE
Fix: ensure defuzzified value is at least 1D

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Coverage
         uses: coverallsapp/github-action@v2
+        with:
+          fail-on-error: false
 
       - name: Benchmark
         uses: CodSpeedHQ/action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,11 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main, feature/*]
+    branches: [ main, feature/* ]
+  schedule: # monthly, first day
+    - cron: 0 0 1 * *
 
 jobs:
   build:
@@ -12,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"] #, "3.7", "3.8", "3.9", "3.10"]
+        python-version: [ "3.9" ] #, "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +28,10 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Check
-        run: nox -e check
+        run: |
+          nox --version
+          poetry --version
+          nox -e check
 
       - name: Install
         run: nox -e install

--- a/fuzzylite/variable.py
+++ b/fuzzylite/variable.py
@@ -515,7 +515,7 @@ class OutputVariable(Variable):
                 f"expected a defuzzifier in output variable '{self.name}', but found None"
             )
         # value at t+1
-        value = self.defuzzifier.defuzzify(self.fuzzy, self.minimum, self.maximum)
+        value = np.atleast_1d(self.defuzzifier.defuzzify(self.fuzzy, self.minimum, self.maximum))
 
         # previous value is the last element of the value at t
         self.previous_value = np.take(self.value, -1).astype(float)
@@ -532,7 +532,6 @@ class OutputVariable(Variable):
 
         # Applying default values
         if not np.isnan(self.default_value):
-            value = np.atleast_1d(value)
             value[np.isnan(value)] = self.default_value
 
         # Committing the value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ mkdocs-material = "^9.1.21" # Documentation with material theme for mkdocs
 mkdocstrings = {extras = ["python"], version = "^0.26.1"}
 mkdocstrings-python = "^1.11.1"
 mypy = "^1.10.0" # Static code analysis
-poetry-bumpversion = "^0.3.0" # Version management
+# poetry-bumpversion = "^0.3.0" # Version management; manual installation to avoid modifying poetry
 pymarkdownlnt = "^0.9.12" # Markdown linter
 pyright = "^1.1.362" # Static code analysis
 pytest = "^7.3.1" # Test driven development

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,12 +1,12 @@
-import fuzzylite as fl
 import unittest
+
 import numpy as np
+
+import fuzzylite as fl
 
 
 class TestIssue91(unittest.TestCase):
-    """
-    Test case for https://github.com/fuzzylite/pyfuzzylite/issues/91
-    """
+    """Test case for https://github.com/fuzzylite/pyfuzzylite/issues/91"""
 
     def engine(self) -> fl.Engine:
         fll = """
@@ -84,3 +84,101 @@ RuleBlock: takagiSugeno
         engine.process()
         np.testing.assert_almost_equal(engine.variable("mTip").value, 25.00104979)
         np.testing.assert_almost_equal(engine.variable("tsTip").value, 25)
+
+    def test_issue_92(self) -> None:
+        class Approximation:
+            def __init__(self) -> None:
+                self.engine = fl.Engine(
+                    name="approximation",
+                    input_variables=[
+                        fl.InputVariable(
+                            name="inputX",
+                            minimum=0.0,
+                            maximum=10.0,
+                            lock_range=False,
+                            terms=[
+                                fl.Triangle("NEAR_1", 0.0, 1.0, 2.0),
+                                fl.Triangle("NEAR_2", 1.0, 2.0, 3.0),
+                                fl.Triangle("NEAR_3", 2.0, 3.0, 4.0),
+                                fl.Triangle("NEAR_4", 3.0, 4.0, 5.0),
+                                fl.Triangle("NEAR_5", 4.0, 5.0, 6.0),
+                                fl.Triangle("NEAR_6", 5.0, 6.0, 7.0),
+                                fl.Triangle("NEAR_7", 6.0, 7.0, 8.0),
+                                fl.Triangle("NEAR_8", 7.0, 8.0, 9.0),
+                                fl.Triangle("NEAR_9", 8.0, 9.0, 10.0),
+                            ],
+                        )
+                    ],
+                    output_variables=[
+                        fl.OutputVariable(
+                            name="outputFx",
+                            minimum=-1.0,
+                            maximum=1.0,
+                            lock_range=False,
+                            lock_previous=True,
+                            default_value=fl.nan,
+                            aggregation=None,
+                            defuzzifier=fl.WeightedAverage(type="TakagiSugeno"),
+                            terms=[
+                                fl.Constant("f1", 0.84),
+                                fl.Constant("f2", 0.45),
+                                fl.Constant("f3", 0.04),
+                                fl.Constant("f4", -0.18),
+                                fl.Constant("f5", -0.19),
+                                fl.Constant("f6", -0.04),
+                                fl.Constant("f7", 0.09),
+                                fl.Constant("f8", 0.12),
+                                fl.Constant("f9", 0.04),
+                            ],
+                        ),
+                        fl.OutputVariable(
+                            name="trueFx",
+                            minimum=-1.0,
+                            maximum=1.0,
+                            lock_range=False,
+                            lock_previous=True,
+                            default_value=fl.nan,
+                            aggregation=None,
+                            defuzzifier=fl.WeightedAverage(),
+                            terms=[fl.Function("fx", "sin(inputX)/inputX")],
+                        ),
+                        fl.OutputVariable(
+                            name="diffFx",
+                            minimum=-1.0,
+                            maximum=1.0,
+                            lock_range=False,
+                            lock_previous=False,
+                            default_value=fl.nan,
+                            aggregation=None,
+                            defuzzifier=fl.WeightedAverage(),
+                            terms=[fl.Function("diff", "fabs(outputFx-trueFx)")],
+                        ),
+                    ],
+                    rule_blocks=[
+                        fl.RuleBlock(
+                            name="",
+                            conjunction=None,
+                            disjunction=None,
+                            implication=None,
+                            activation=fl.General(),
+                            rules=[
+                                fl.Rule.create("if inputX is NEAR_1 then outputFx is f1"),
+                                fl.Rule.create("if inputX is NEAR_2 then outputFx is f2"),
+                                fl.Rule.create("if inputX is NEAR_3 then outputFx is f3"),
+                                fl.Rule.create("if inputX is NEAR_4 then outputFx is f4"),
+                                fl.Rule.create("if inputX is NEAR_5 then outputFx is f5"),
+                                fl.Rule.create("if inputX is NEAR_6 then outputFx is f6"),
+                                fl.Rule.create("if inputX is NEAR_7 then outputFx is f7"),
+                                fl.Rule.create("if inputX is NEAR_8 then outputFx is f8"),
+                                fl.Rule.create("if inputX is NEAR_9 then outputFx is f9"),
+                                fl.Rule.create(
+                                    "if inputX is any then trueFx is fx and diffFx is diff"
+                                ),
+                            ],
+                        )
+                    ],
+                )
+
+        test = Approximation()
+        test.engine.input_variable("inputX").value = 5.0
+        test.engine.process()


### PR DESCRIPTION
Issue: https://github.com/fuzzylite/help/issues/14

Problem: defuzzified value is a single scalar, which cannot be iterated upon to lock previous values

Solution: make sure any defuzzified value is at least 1D.

## Requirements
- [ ] `HISTORY` file is updated
- [X] Code is tested
- [X] Documentation is updated
