### PR TITLE
8.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" markdown=1>
 <img src="/fuzzylite.png" alt="fuzzylite" width="10%">
-<h1>pyfuzzylite 8.0.5</h1>
+<h1>pyfuzzylite 8.0.6</h1>
 <h2>A Fuzzy Logic Control Library in Python</h2>
 <h3>by <a href="https://fuzzylite.com/about"><b>Juan Rada-Vilela, PhD</b></a></h3>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <div align="center" markdown=1>
 <img src="/image/fuzzylite.svg" alt="fuzzylite" width="10%">
-<h1>pyfuzzylite 8.0.5</h1>
+<h1>pyfuzzylite 8.0.6</h1>
 <h2>A Fuzzy Logic Control Library in Python</h2>
 <h3>by <a href="https://fuzzylite.com/about"><b>Juan Rada-Vilela, PhD</b></a></h3>
 

--- a/fuzzylite/library.py
+++ b/fuzzylite/library.py
@@ -267,7 +267,7 @@ class Information:
         Returns:
             version of the library
         """
-        __version__ = "8.0.5"
+        __version__ = "8.0.6"
         return __version__
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyfuzzylite"
-version = "8.0.5"
+version = "8.0.6"
 description = "a fuzzy logic control library in Python"
 license = "Proprietary"
 readme = "README.md"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -70,7 +70,7 @@ variable InputVariable OutputVariable Variable
 
     def test_library_vars(self) -> None:
         """Test the library variables."""
-        __version__ = "8.0.5"
+        __version__ = "8.0.6"
         self.assertTrue("fuzzylite" == fl.__name__ == fl.information.name)
         self.assertTrue(__version__ == fl.__version__ == fl.information.version)
         self.assertTrue(


### PR DESCRIPTION
Fix bug when locking output variables and using scalars instead of numpy arrays (https://github.com/fuzzylite/help/issues/14)